### PR TITLE
Target Android 16 (SDK 36) and update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,12 +4,12 @@ plugins {
 
 android {
     namespace = 'com.dimadesu.bondbunny'
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.dimadesu.bondbunny"
         minSdk 26
-        targetSdk 35
+        targetSdk 36
         versionCode 13
         versionName "1.14.2"
         
@@ -63,12 +63,12 @@ android {
     }
 
     // Enable NDK (needed for ndk.abiFilters in defaultConfig)
-    ndkVersion = "25.1.8937393"
+    ndkVersion = "29.0.14206865"
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.10.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation project(':srtla-lib')
 }
 

--- a/srtla-lib/build.gradle
+++ b/srtla-lib/build.gradle
@@ -8,7 +8,7 @@ group = 'com.dimadesu.bondbunny'
 
 android {
     namespace = 'com.dimadesu.bondbunny.srtlalib'
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         minSdk 24
@@ -38,7 +38,7 @@ android {
         }
     }
 
-    ndkVersion = "25.1.8937393"
+    ndkVersion = "29.0.14206865"
 
     externalNativeBuild {
         cmake {
@@ -49,8 +49,8 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.10.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.12.0'
 
     // Moblink streamer: WebSocket server + JSON protocol
     implementation 'org.java-websocket:Java-WebSocket:1.5.7'


### PR DESCRIPTION
- compileSdk and targetSdk: 35 → 36
- NDK: r25 (25.1.8937393) → r29 (29.0.14206865)
- androidx.appcompat: 1.6.1 → 1.7.1
- com.google.android.material: 1.10.0 → 1.12.0

No source code changes required. The app already handles SDK 36 behavioral changes:
- Edge-to-edge: all root layouts use fitsSystemWindows="true"
- Predictive back: no onBackPressed() overrides
- Adaptive layouts: no orientation locks in manifest
- Foreground service: onTimeout() already implemented for dataSync